### PR TITLE
Fix error when vagrant-openstack-provider not installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant/
 kube-deploy/kube-deploy.retry
+ubuntu-xenial-16.04-cloudimg-console.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,6 @@
 # vi: set ft=ruby :
 # NOTE: Variable overrides are in ./config.rb
 require "yaml"
-require "vagrant-openstack-provider"
 require "fileutils"
 
 # Use a variable file for overrides:
@@ -31,6 +30,9 @@ end
 if missing_plugins_installed
   exec "vagrant #{ARGV.join(" ")}"
 end
+
+# Use plugins after install / re-run
+require "vagrant-openstack-provider"
 
 # Vagrantfile API/sytax version. Don’t touch unless you know what you’re doing!
 VAGRANTFILE_API_VERSION = "2"


### PR DESCRIPTION
Fixes this problem when `vagrant-openstack-provider` was not already installed.

``` sh-session
cgilmour@cg-macbookpro:~/Development/halcyon-kubernetes$ vagrant up
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /Users/cgilmour/Development/halcyon-kubernetes/Vagrantfile
Line number: 5
Message: LoadError: cannot load such file -- vagrant-openstack-provider
```

Also adds `ubuntu-xenial-16.04-cloudimg-console.log` to `.gitignore`.
