### PR TITLE
Option to set hostname-override for kubelet

### DIFF
--- a/kube-deploy/group_vars/all.yml
+++ b/kube-deploy/group_vars/all.yml
@@ -17,3 +17,4 @@
 bootstrap_os: ubuntu
 init_token: fa7ed3.c5debcef8dd01970
 public_iface: enp0s8
+kubelet_hostname_override: true

--- a/kube-deploy/kube-deploy.yml
+++ b/kube-deploy/kube-deploy.yml
@@ -23,7 +23,7 @@
     - upgrade-os
 
 - hosts: all
-  gather_facts: false
+  gather_facts: true
   become: yes
   roles:
     - deploy-kube

--- a/kube-deploy/roles/deploy-kube/tasks/ubuntu.yml
+++ b/kube-deploy/roles/deploy-kube/tasks/ubuntu.yml
@@ -16,3 +16,16 @@
   - kubeadm
   - kubectl
   - kubernetes-cni
+
+- name: add kubelet.service drop-in for hostname override
+  template: src="15-hostname-override.conf.j2" dest="/etc/systemd/system/kubelet.service.d/15-hostname-override.conf" mode=0640
+  when: kubelet_hostname_override
+  register: kho
+
+- name: reload systemd config
+  command: systemctl daemon-reload
+  when: kho.changed
+
+- name: restart kubelet service
+  service: name=kubelet state=restarted
+  when: kho.changed

--- a/kube-deploy/roles/deploy-kube/templates/15-hostname-override.conf.j2
+++ b/kube-deploy/roles/deploy-kube/templates/15-hostname-override.conf.j2
@@ -1,0 +1,4 @@
+[Service]
+Environment="KUBELET_HOSTNAME_OVERRIDE=--hostname-override={{ hostvars[inventory_hostname]['ansible_'+public_iface].ipv4.address }}"
+ExecStart=
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_EXTRA_ARGS $KUBELET_HOSTNAME_OVERRIDE


### PR DESCRIPTION
In vagrant, all the nodes seem to come up with the NAT interface address (`10.0.2.15`).
This lets you set `kubelet_hostname_override`, which will make it use the address from `public_iface` when kubelet is launched.

``` sh-session
root@kube1:~# kubectl get nodes 
NAME           STATUS    AGE
172.16.35.11   Ready     21m
172.16.35.12   Ready     20m
172.16.35.13   Ready     20m
```
