### PR TITLE
Minor updates related to Romana, routes and CIDRs.

### DIFF
--- a/kube-deploy/group_vars/all.yml
+++ b/kube-deploy/group_vars/all.yml
@@ -24,6 +24,7 @@ kubelet_hostname_override: true
 kubectl_endpoint: kube1
 
 # Kubernetes SDN Deployment:
+kube_cluster_ip_cidr: 10.96.0.0/12
 kube_sdn_deploy: true
 kube_sdn: romana
 
@@ -31,4 +32,4 @@ kube_sdn: romana
 kube_dashboard: true
 
 # SDN-Specific Config
-romana_version: v0.9.3.4
+romana_version: v0.9.3.5

--- a/kube-deploy/roles/kube-prep/tasks/main.yml
+++ b/kube-deploy/roles/kube-prep/tasks/main.yml
@@ -14,5 +14,10 @@
 # limitations under the License.
 #
 
+- name: add route for service cluster ip range
+  shell: ip route add {{ kube_cluster_ip_cidr }} dev {{ public_iface }}
+  when: not (public_iface == nat_iface)
+  ignore_errors: true
+
 - include: prep-romana.yml
   when: (kube_sdn == 'romana')

--- a/kube-deploy/roles/kube-prep/tasks/prep-romana.yml
+++ b/kube-deploy/roles/kube-prep/tasks/prep-romana.yml
@@ -14,11 +14,6 @@
 # limitations under the License.
 #
 
-- name: add route for service cluster ip range
-  shell: ip route add 10.96.0.0/12 dev {{ public_iface }}
-  when: not (public_iface == nat_iface)
-  ignore_errors: true
-
 - name: pull romana container for master
   shell: docker pull {{ item }}
   with_items:

--- a/kube-deploy/roles/kube-sdn/templates/romana.j2
+++ b/kube-deploy/roles/kube-sdn/templates/romana.j2
@@ -73,7 +73,7 @@ spec:
         - --romana-root=http://10.99.99.99:9600
         - --interface={{ public_iface }}
         - --nat-interface={{ nat_iface }}
-        - --cluster-ip-cidr=10.96.0.0/12
+        - --cluster-ip-cidr={{ kube_cluster_ip_cidr }}
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Adds a new variable `kube_cluster_ip_cidr`. Value is the default used by kubeadm.
This seems to be needed for romana, weave and possibly other SDNs when running in vagrant, to ensure the clusterIP traffic is routed via the host-only network.

Routes are added in kube-prep regardless of SDN type, as it's not romana-specific.

Also version bump of Romana.