### PR TITLE
Update CentOS install to use upstream docker

### DIFF
--- a/kube-deploy/roles/deploy-kube/tasks/centos.yml
+++ b/kube-deploy/roles/deploy-kube/tasks/centos.yml
@@ -36,7 +36,7 @@
 - name: install kubeadm and required prereqs
   yum: name={{ item }} update_cache=yes state=present state=latest
   with_items:
-  - docker
+  - docker-engine
   - kubelet
   - kubeadm
   - kubectl
@@ -72,4 +72,3 @@
 
 - name: restart kubelet
   command: systemctl restart kubelet
-


### PR DESCRIPTION
This commit updates deploy-kube to use the upstream docker rpm from
the docker repo, as the current docker in the CentOS repos is lagging
behind and has some performance issues.