### PR TITLE
Update romana version

### DIFF
--- a/kube-deploy/group_vars/all.yml
+++ b/kube-deploy/group_vars/all.yml
@@ -29,7 +29,7 @@ kubelet_hostname_override: true
 kube_cluster_ip_cidr: 10.96.0.0/12
 kube_sdn_deploy: true
 kube_sdn: romana
-romana_version: v0.9.3.5
+romana_version: v0.9.3.6
 #
 #
 ## Kubernetes Add-Ons:


### PR DESCRIPTION
This commit updates the Romana version to v0.9.3.6; which fixes a bug in the policy agent which prevented operation on CentOS 7.2: https://github.com/romana/romana/issues/143