### PR TITLE
Add support for setting up docker daemon shared bind mounts

### DIFF
--- a/kube-deploy/group_vars/all.yml
+++ b/kube-deploy/group_vars/all.yml
@@ -39,3 +39,7 @@ kube_addons_enabled: true
 kube_addons:
   - kube_dashboard
   - kube_helm
+#
+## Docker Daemon Options:
+# Shared mounts is required for several OpenStack Kolla-Kubernetes components.
+docker_shared_mounts: false

--- a/kube-deploy/roles/deploy-kube/tasks/centos.yml
+++ b/kube-deploy/roles/deploy-kube/tasks/centos.yml
@@ -48,6 +48,19 @@
 - name: turn off SELinux
   command: setenforce 0
 
+- name: setting up docker unit drop-in dir
+  file: path=/etc/systemd/system/docker.service.d state=directory
+  when: docker_shared_mounts
+
+- name: setting up docker shared mounts
+  template: src="10-docker-shared-mounts.conf.j2" dest="/etc/systemd/system/docker.service.d/10-docker-shared-mounts.conf" mode=0640
+  when: docker_shared_mounts
+  register: dsm
+
+- name: reload systemd config
+  command: systemctl daemon-reload
+  when: dsm.changed
+
 - name: start docker service
   service: enabled=yes state=started name=docker
 

--- a/kube-deploy/roles/deploy-kube/tasks/ubuntu.yml
+++ b/kube-deploy/roles/deploy-kube/tasks/ubuntu.yml
@@ -17,6 +17,23 @@
   - kubectl
   - kubernetes-cni
 
+- name: setting up docker unit drop-in dir
+  file: path=/etc/systemd/system/docker.service.d state=directory
+  when: docker_shared_mounts
+
+- name: setting up docker shared mounts
+  template: src="10-docker-shared-mounts.conf.j2" dest="/etc/systemd/system/docker.service.d/10-docker-shared-mounts.conf" mode=0640
+  when: docker_shared_mounts
+  register: dsm
+
+- name: reload systemd config
+  command: systemctl daemon-reload
+  when: dsm.changed
+
+- name: restart docker service
+  service: name=docker state=restarted
+  when: dsm.changed
+
 - name: add kubelet.service drop-in for hostname override
   template: src="15-hostname-override.conf.j2" dest="/etc/systemd/system/kubelet.service.d/15-hostname-override.conf" mode=0640
   when: kubelet_hostname_override

--- a/kube-deploy/roles/deploy-kube/templates/10-docker-shared-mounts.conf.j2
+++ b/kube-deploy/roles/deploy-kube/templates/10-docker-shared-mounts.conf.j2
@@ -1,0 +1,2 @@
+[Service]
+MountFlags=shared


### PR DESCRIPTION
This commit adds support for setting up the docker daemon to permit shared bind mounts, this is required for many OpenStack Kolla containers to function correctly (e.g. Neutron and Cinder with LVM).