### PR TITLE
Support initial kolla-k8s dev requirements

### DIFF
--- a/kube-deploy/group_vars/all.yml
+++ b/kube-deploy/group_vars/all.yml
@@ -28,6 +28,7 @@ kube_version: v1.5.0-beta.1
 #
 ## Kubernetes SDN Deployment Options:
 kube_cluster_ip_cidr: 10.96.0.0/12
+kube_service_dns_domain: cluster.local
 kube_sdn_deploy: true
 kube_sdn: weave
 romana_version: v0.9.3.6
@@ -40,6 +41,9 @@ kube_addons:
   - kube_dashboard
   - kube_helm
 #
+## Helm Parameters:
+helm_version: v2.0.0
+#
 ## Docker Daemon Options:
 # Shared mounts is required for several OpenStack Kolla-Kubernetes components.
 docker_shared_mounts: false
@@ -49,3 +53,7 @@ docker_shared_mounts: false
 setup_host_kube_dns: false
 # Setup the host for ceph
 setup_host_ceph: false
+# Patch kubernetes-controller-manager for ceph PVC support
+# This pulls in the quay.io/attcomdev/kube-controller-manager:v1.5.0-beta.1
+# to replace the upstream image
+patch_kube_ceph: false

--- a/kube-deploy/roles/kube-prep/tasks/main.yml
+++ b/kube-deploy/roles/kube-prep/tasks/main.yml
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+- include: patch-kube.yml
+
 - name: add route for service cluster ip range
   shell: ip route add {{ kube_cluster_ip_cidr }} dev {{ public_iface }}
   when: not (public_iface == nat_iface)

--- a/kube-deploy/roles/kube-prep/tasks/patch-kube.yml
+++ b/kube-deploy/roles/kube-prep/tasks/patch-kube.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2016, JinkIT, and it's Authors.
+# Copyright 2016, Port.direct, LTD
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,7 @@
 # limitations under the License.
 #
 
-- name: deploying helm tool
-  shell: curl -L http://storage.googleapis.com/kubernetes-helm/helm-{{ helm_version }}-linux-amd64.tar.gz | tar zxv --strip 1 -C /tmp; chmod +x /tmp/helm; mv /tmp/helm /usr/local/bin/helm
-  when: kube_addons_enabled and "{{kube_addons.kube_helm is defined}}"
-  ignore_errors: true
-
-- name: initializing helm deployment
-  command: /usr/local/bin/helm init
-  when: kube_addons_enabled and "{{kube_addons.kube_helm is defined}}"
+- name: patch kube-controller-manager to support ceph pvc creation
+  command: sed -i "s|gcr.io/google_containers/kube-controller-manager-amd64:{{ kube_version }}|quay.io/attcomdev/kube-controller-manager:v1.5.0-beta.1|g" /etc/kubernetes/manifests/kube-controller-manager.json
+  when: patch_kube_ceph and inventory_hostname in groups['kube-masters']
   ignore_errors: true

--- a/kube-deploy/roles/kube-prep/tasks/prep-host-dns.yml
+++ b/kube-deploy/roles/kube-prep/tasks/prep-host-dns.yml
@@ -30,6 +30,26 @@
     kube_dns_ip_addr: "{{ item.stdout }}"
   with_items: "{{ kube_dns_ip.results }}"
 
+- name: getting current external dns ip from kubernetes masters
+  shell: cat /etc/resolv.conf | awk '$1 == "nameserver" { print $NF }' | head -n1
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  with_items: "{{ groups['kube-masters'] }}"
+  register: external_dns_ip
+
+- name: setting external-dns ip fact
+  set_fact:
+    external_dns_ip_addr: "{{ item.stdout }}"
+  with_items: "{{ external_dns_ip.results }}"
+
+- name: telling network manager to leave resolv.conf alone
+  shell: sed -i '/\[main\]/adns=none' /etc/NetworkManager/NetworkManager.conf
+  when: bootstrap_os == "centos"
+
+- name: disabling resolvconf
+  shell: rm -f /etc/resolv.conf && cp /run/resolvconf/resolv.conf /etc/resolv.conf
+  when: bootstrap_os == "ubuntu"
+
 # Setup the host's resolve conf to use the k8s dns server
 - name: setting up host resolve conf to use kube dns
   template: src="resolv.conf.j2" dest="/etc/resolv.conf" mode=0644

--- a/kube-deploy/roles/kube-prep/templates/resolv.conf.j2
+++ b/kube-deploy/roles/kube-prep/templates/resolv.conf.j2
@@ -1,8 +1,7 @@
 # Created by halcyon-kubernetes
-search default.svc.cluster.local svc.cluster.local cluster.local
+search default.svc.{{ kube_service_dns_domain }} svc.{{ kube_service_dns_domain }} {{ kube_service_dns_domain }}
 nameserver {{ kube_dns_ip_addr }}
-nameserver 8.8.8.8
-nameserver 8.8.4.4
+nameserver {{ external_dns_ip_addr }}
 options ndots:5
 # These options enable hostname resolution to work when the kube-dns service
 # is unavalible without an absolutely atrocious performance impact.


### PR DESCRIPTION
This commit brings in cleaned up changes from the portdirect fork of halycon-kubernetes to allow kolla-k8s development from the att-comdev repo.

Author:    portdirect <pete@port.direct>