### PR TITLE
Create docker proxy configuration file

### DIFF
--- a/kube-deploy/roles/deploy-kube/tasks/centos.yml
+++ b/kube-deploy/roles/deploy-kube/tasks/centos.yml
@@ -50,19 +50,27 @@
 
 - name: setting up docker unit drop-in dir
   file: path=/etc/systemd/system/docker.service.d state=directory
-  when: docker_shared_mounts
+  when: docker_shared_mounts or proxy_enable
 
 - name: setting up docker shared mounts
   template: src="10-docker-shared-mounts.conf.j2" dest="/etc/systemd/system/docker.service.d/10-docker-shared-mounts.conf" mode=0640
   when: docker_shared_mounts
   register: dsm
 
+# Vagrant's proxyconf plugin doesn't properly set up docker proxy and
+# even if it did, would require a vargrant reload after docker install
+# in order to take effect.
+- name: setting up docker proxy
+  template: src="20-docker-proxy.conf.j2" dest="/etc/systemd/system/docker.service.d/20-docker-proxy.conf" mode=0640
+  when: proxy_enable
+  register: docker_proxy
+
 - name: reload systemd config
   command: systemctl daemon-reload
-  when: dsm.changed
+  when: dsm.changed or docker_proxy.changed
 
 - name: start docker service
-  service: enabled=yes state=started name=docker
+  service: enabled=yes state=restarted name=docker
 
 - name: start kubelet service
   service: enabled=yes state=started name=kubelet

--- a/kube-deploy/roles/deploy-kube/tasks/ubuntu.yml
+++ b/kube-deploy/roles/deploy-kube/tasks/ubuntu.yml
@@ -19,20 +19,29 @@
 
 - name: setting up docker unit drop-in dir
   file: path=/etc/systemd/system/docker.service.d state=directory
-  when: docker_shared_mounts
+  when: docker_shared_mounts or proxy_enable
 
 - name: setting up docker shared mounts
   template: src="10-docker-shared-mounts.conf.j2" dest="/etc/systemd/system/docker.service.d/10-docker-shared-mounts.conf" mode=0640
   when: docker_shared_mounts
   register: dsm
 
+# Vagrant's proxyconf plugin would set up the docker proxy for us, but
+# for this to happen, a vagrant reload would be required after docker is
+# installed and before continuing with the rest of the playbook, so we
+# configure it manually here.
+- name: setting up docker proxy
+  template: src="20-docker-proxy.conf.j2" dest="/etc/systemd/system/docker.service.d/20-docker-proxy.conf" mode=0640
+  when: proxy_enable
+  register: docker_proxy
+
 - name: reload systemd config
   command: systemctl daemon-reload
-  when: dsm.changed
+  when: dsm.changed or docker_proxy.changed
 
 - name: restart docker service
   service: name=docker state=restarted
-  when: dsm.changed
+  when: dsm.changed or docker_proxy.changed
 
 - name: add kubelet.service drop-in for hostname override
   template: src="15-hostname-override.conf.j2" dest="/etc/systemd/system/kubelet.service.d/15-hostname-override.conf" mode=0640

--- a/kube-deploy/roles/deploy-kube/templates/20-docker-proxy.conf.j2
+++ b/kube-deploy/roles/deploy-kube/templates/20-docker-proxy.conf.j2
@@ -1,0 +1,4 @@
+[Service]
+Environment="HTTP_PROXY={{ proxy_http }}"
+Environment="HTTPS_PROXY={{ proxy_https }}"
+Environment="NO_PROXY={{ proxy_no }}"


### PR DESCRIPTION
Creates a docker proxy configuration file to fix issue #26 

Although vagrant-proxyconf should set this up, it requires a vagrant reload to take effect (and doesn't set up the proxies correctly for centos).  By setting up the proxy conf through the playbook, it can run to completion without requiring a reload in the middle.