### PR TITLE
Add loopback devices for Kolla-Kubernetes Ceph

### DIFF
--- a/kube-deploy/roles/kube-prep/tasks/prep-ceph-loopback.yml
+++ b/kube-deploy/roles/kube-prep/tasks/prep-ceph-loopback.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2016, JinkIT, and it's Authors.
+# Copyright 2016, Port.direct, LTD
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,18 +14,15 @@
 # limitations under the License.
 #
 
-- include: patch-kube.yml
-
-- name: add route for service cluster ip range
-  shell: ip route add {{ kube_cluster_ip_cidr }} dev {{ public_iface }}
-  when: not (public_iface == nat_iface)
+- name: setting up loopback device to use for ceph
+  shell: |
+         mkdir -p /data/kolla;
+         dd if=/dev/zero of=/data/kolla/ceph-osd0.img bs=5M count=1024;
+         LOOP=$(losetup -f);
+         losetup $LOOP /data/kolla/ceph-osd0.img;
+         parted $LOOP mklabel gpt;
+         parted $LOOP mkpart 1 0% 512m;
+         parted $LOOP mkpart 2 513m 100%;
+         partprobe;
+  when: setup_host_ceph and inventory_hostname in groups['kube-workers']
   ignore_errors: true
-
-- include: prep-romana.yml
-  when: (kube_sdn == 'romana')
-
-- include: prep-host-dns.yml
-  when: setup_host_kube_dns
-
-- include: prep-ceph-loopback.yml
-  when: setup_host_ceph


### PR DESCRIPTION
This commit adds the creation of a loop-back device with two partitions for Kolla Ceph support, the first is to be used as a Journal while the 2nd for the OSD.