### PR TITLE
ARM Support for halcyon-kubernetes

### DIFF
--- a/kube-deploy/group_vars/all.yml
+++ b/kube-deploy/group_vars/all.yml
@@ -18,6 +18,8 @@ bootstrap_os: ubuntu
 public_iface: enp0s3
 nat_iface: enp0s3
 proxy_enable: false
+#Only enable this if you are deploying on ARM or ARM64 with Fannel SDN provider
+arm_enabled: true
 #
 #
 ## Kubernetes Parameters:
@@ -31,7 +33,9 @@ kube_version: v1.5.1
 kube_cluster_ip_cidr: 10.96.0.0/12
 kube_service_dns_domain: cluster.local
 kube_sdn_deploy: true
-kube_sdn: weave
+#kube_sdn: weave
+kube_sdn: flannel
+
 #
 ## Kubernetes SDN Versioning:
 calico_version: v2.0

--- a/kube-deploy/group_vars/all.yml
+++ b/kube-deploy/group_vars/all.yml
@@ -31,7 +31,7 @@ kube_version: v1.5.1
 kube_cluster_ip_cidr: 10.96.0.0/12
 kube_service_dns_domain: cluster.local
 kube_sdn_deploy: true
-kube_sdn: flannel
+kube_sdn: weave
 
 #
 ## Kubernetes SDN Versioning:

--- a/kube-deploy/group_vars/all.yml
+++ b/kube-deploy/group_vars/all.yml
@@ -18,8 +18,6 @@ bootstrap_os: ubuntu
 public_iface: enp0s3
 nat_iface: enp0s3
 proxy_enable: false
-#Only enable this if you are deploying on ARM or ARM64 with Fannel SDN provider
-arm_enabled: false
 #
 #
 ## Kubernetes Parameters:
@@ -33,7 +31,7 @@ kube_version: v1.5.1
 kube_cluster_ip_cidr: 10.96.0.0/12
 kube_service_dns_domain: cluster.local
 kube_sdn_deploy: true
-kube_sdn: weave
+kube_sdn: flannel
 
 #
 ## Kubernetes SDN Versioning:

--- a/kube-deploy/group_vars/all.yml
+++ b/kube-deploy/group_vars/all.yml
@@ -19,7 +19,7 @@ public_iface: enp0s3
 nat_iface: enp0s3
 proxy_enable: false
 #Only enable this if you are deploying on ARM or ARM64 with Fannel SDN provider
-arm_enabled: true
+arm_enabled: false
 #
 #
 ## Kubernetes Parameters:
@@ -33,8 +33,7 @@ kube_version: v1.5.1
 kube_cluster_ip_cidr: 10.96.0.0/12
 kube_service_dns_domain: cluster.local
 kube_sdn_deploy: true
-#kube_sdn: weave
-kube_sdn: flannel
+kube_sdn: weave
 
 #
 ## Kubernetes SDN Versioning:

--- a/kube-deploy/group_vars/all.yml
+++ b/kube-deploy/group_vars/all.yml
@@ -18,8 +18,6 @@ bootstrap_os: ubuntu
 public_iface: enp0s3
 nat_iface: enp0s3
 proxy_enable: false
-#Only enable this if you are deploying on ARM or ARM64 with Fannel SDN provider
-arm_enabled: false
 #
 #
 ## Kubernetes Parameters:

--- a/kube-deploy/roles/kube-addons/tasks/addons-dashboard.yml
+++ b/kube-deploy/roles/kube-addons/tasks/addons-dashboard.yml
@@ -14,12 +14,18 @@
 # limitations under the License.
 #
 
+#For ARM support only
+- name: Checking for ARM support
+  shell: uname -a | grep -i "arm"
+  register: arm_enabled
+  ignore_errors: true
+
 - name: deploying the kubernetes dashboard
   shell: kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
-  when: kube_addons_enabled and "{{kube_addons.kube_dashboard is defined}}"
+  when: kube_addons_enabled and "{{kube_addons.kube_dashboard is defined}}" and arm_enabled.rc != 0
   ignore_errors: true
 
 - name: deploying the kubernetes dashboard - ARM support only
   shell: curl -sSL https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml | sed "s/amd64/arm64/g" | kubectl create -f -
-  when: kube_addons_enabled and "{{kube_addons.kube_dashboard is defined}}" and arm_enabled == 'true'
+  when: kube_addons_enabled and "{{kube_addons.kube_dashboard is defined}}" and arm_enabled.rc == 0
   ignore_errors: true

--- a/kube-deploy/roles/kube-addons/tasks/addons-dashboard.yml
+++ b/kube-deploy/roles/kube-addons/tasks/addons-dashboard.yml
@@ -14,18 +14,48 @@
 # limitations under the License.
 #
 
-#For ARM support only
-- name: Checking for ARM support
-  shell: uname -a | grep -i "arm"
-  register: arm_enabled
-  ignore_errors: true
+#Checking for Architecture Support
+- name: Checking for x86_64 architecture
+  set_fact:
+    host_arch: "amd64"
+  when: "'x86_64' in ansible_architecture"
+
+- name: Checking for arm architecture
+  set_fact:
+    host_arch: "arm"
+  when: "'arm' in ansible_architecture"
+
+- name: Checking for aarch64 architecture
+  set_fact:
+    host_arch: "arm64"
+  when: "'aarch64' in ansible_architecture"
+
+- name: Checking for arm64 architecture
+  set_fact:
+    host_arch: "arm64"
+  when: "'arm64' in ansible_architecture"
+
+- name: Checking for s390x architecture
+  set_fact:
+    host_arch: "s390x"
+  when: "'s390x' in ansible_architecture"
+
+- name: Checking for ppc64le architecture
+  set_fact:
+    host_arch: "ppc64le"
+  when: "'ppc64le' in ansible_architecture"
+
+- name: Assign default architecture if undefined
+  set_fact:
+    host_arch: "amd64"
+  when: host_arch is undefined
 
 - name: deploying the kubernetes dashboard
   shell: kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
-  when: kube_addons_enabled and "{{kube_addons.kube_dashboard is defined}}" and arm_enabled.rc != 0
+  when: kube_addons_enabled and "{{kube_addons.kube_dashboard is defined}}" and host_arch == "amd64"
   ignore_errors: true
 
-- name: deploying the kubernetes dashboard - ARM support only
-  shell: curl -sSL https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml | sed "s/amd64/arm64/g" | kubectl create -f -
-  when: kube_addons_enabled and "{{kube_addons.kube_dashboard is defined}}" and arm_enabled.rc == 0
+- name: deploying the kubernetes dashboard - non X86 only
+  shell: curl -sSL https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml | sed "s/amd64/{{ ansible_architecture }}/g" | kubectl create -f -
+  when: kube_addons_enabled and "{{kube_addons.kube_dashboard is defined}}" and host_arch != "amd64"
   ignore_errors: true

--- a/kube-deploy/roles/kube-addons/tasks/addons-dashboard.yml
+++ b/kube-deploy/roles/kube-addons/tasks/addons-dashboard.yml
@@ -18,3 +18,8 @@
   shell: kubectl create -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
   when: kube_addons_enabled and "{{kube_addons.kube_dashboard is defined}}"
   ignore_errors: true
+
+- name: deploying the kubernetes dashboard - ARM support only
+  shell: curl -sSL https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml | sed "s/amd64/arm64/g" | kubectl create -f -
+  when: kube_addons_enabled and "{{kube_addons.kube_dashboard is defined}}" and arm_enabled == 'true'
+  ignore_errors: true

--- a/kube-deploy/roles/kube-sdn/tasks/kube-flannel.yml
+++ b/kube-deploy/roles/kube-sdn/tasks/kube-flannel.yml
@@ -15,37 +15,72 @@
 #
 
 - name: Flannel Installation
-  debug: msg="starting flannel installation"
+  debug:
+    msg: "Starting Flannel Installation"
 
-#For ARM Support Only
-- name: Check to see if the platform is ARM enabled
-  shell: uname -a | grep -i "arm"
-  register: arm_enabled
-  ignore_errors: true
+#Checking for Architecture Support
+- name: Checking for x86_64 architecture
+  set_fact:
+    host_arch: "amd64"
+  when: "'x86_64' in ansible_architecture"
+
+- name: Checking for arm architecture
+  set_fact:
+    host_arch: "arm"
+  when: "'arm' in ansible_architecture"
+
+- name: Checking for aarch64 architecture
+  set_fact:
+    host_arch: "arm64"
+  when: "'aarch64' in ansible_architecture"
+
+- name: Checking for arm64 architecture
+  set_fact:
+    host_arch: "arm64"
+  when: "'arm64' in ansible_architecture"
+
+- name: Checking for s390x architecture
+  set_fact:
+    host_arch: "s390x"
+  when: "'s390x' in ansible_architecture"
+
+- name: Checking for ppc64le architecture
+  set_fact:
+    host_arch: "ppc64le"
+  when: "'ppc64le' in ansible_architecture"
+
+- name: Assign default architecture if undefined
+  set_fact:
+    host_arch: "amd64"
+  when: host_arch is undefined
 
 - name: ensure sdn bootstrap directory exists
-  file: path=/etc/kubernetes/halcyon/network state=directory
+  file:
+    path: /etc/kubernetes/halcyon/network
+    state: directory
   when: kube_sdn_deploy == True
   ignore_errors: true
 
-- name: deploying flannel for kubernetes
+- name: deploying flannel for kubernetes - x86_64
   shell: kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
   register: deploy_flannel
-  when: (kube_sdn == 'flannel' and arm_enabled.rc != 0)
+  when: kube_sdn == 'flannel' and host_arch == "amd64"
   ignore_errors: true
 
-- name: deploying flannel for kubernetes - ARM support only
-  shell: curl -sSL https://rawgit.com/coreos/flannel/master/Documentation/kube-flannel.yml | sed "s/amd64/arm64/g" | kubectl create -f -
-  register: deploy_flannel_arm
-  when: (kube_sdn == 'flannel' and arm_enabled.rc == 0)
+- name: deploying flannel for kubernetes - Alternative Architectures
+  shell: curl -sSL https://rawgit.com/coreos/flannel/master/Documentation/kube-flannel.yml | sed "s/amd64/{{ host_arch }}/g" | kubectl create -f -
+  register: deploy_flannel_alt_arch
+  when: kube_sdn == 'flannel' and host_arch != "amd64"
   ignore_errors: true
-
-- name: flannel deployment stdout
-  debug: msg={{ deploy_flannel }}
-  ignore_errors: true
-  when: arm_enabled.rc != 0
 
 - name: flannel deployment stdout
-  debug: msg={{ deploy_flannel_arm }}
+  debug:
+    msg: "{{ deploy_flannel }}"
   ignore_errors: true
-  when: arm_enabled.rc == 0
+  when: host_arch == "amd64"
+
+- name: flannel deployment stdout
+  debug:
+    msg: "{{ deploy_flannel_alt_arch }} for architecture: {{ host_arch }}"
+  ignore_errors: true
+  when: host_arch != "amd64"

--- a/kube-deploy/roles/kube-sdn/tasks/kube-flannel.yml
+++ b/kube-deploy/roles/kube-sdn/tasks/kube-flannel.yml
@@ -17,6 +17,12 @@
 - name: Flannel Installation
   debug: msg="starting flannel installation"
 
+#For ARM Support Only
+- name: Check to see if the platform is ARM enabled
+  shell: uname -a | grep -i "arm"
+  register: arm_enabled
+  ignore_errors: true
+
 - name: ensure sdn bootstrap directory exists
   file: path=/etc/kubernetes/halcyon/network state=directory
   when: kube_sdn_deploy == True
@@ -25,21 +31,21 @@
 - name: deploying flannel for kubernetes
   shell: kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
   register: deploy_flannel
-  when: (kube_sdn == 'flannel' and arm_enabled == False)
+  when: (kube_sdn == 'flannel' and arm_enabled.rc != 0)
   ignore_errors: true
 
 - name: deploying flannel for kubernetes - ARM support only
   shell: curl -sSL https://rawgit.com/coreos/flannel/master/Documentation/kube-flannel.yml | sed "s/amd64/arm64/g" | kubectl create -f -
   register: deploy_flannel_arm
-  when: (kube_sdn == 'flannel' and arm_enabled == True)
+  when: (kube_sdn == 'flannel' and arm_enabled.rc == 0)
   ignore_errors: true
 
 - name: flannel deployment stdout
   debug: msg={{ deploy_flannel }}
   ignore_errors: true
-  when: arm_enabled == False
+  when: arm_enabled.rc != 0
 
 - name: flannel deployment stdout
   debug: msg={{ deploy_flannel_arm }}
   ignore_errors: true
-  when: arm_enabled == True
+  when: arm_enabled.rc == 0

--- a/kube-deploy/roles/kube-sdn/tasks/kube-flannel.yml
+++ b/kube-deploy/roles/kube-sdn/tasks/kube-flannel.yml
@@ -14,18 +14,13 @@
 # limitations under the License.
 #
 
-- name: placeholder for flannel
+- name: Flannel Installation
   debug: msg="starting flannel installation"
 
 - name: ensure sdn bootstrap directory exists
   file: path=/etc/kubernetes/halcyon/network state=directory
   when: kube_sdn_deploy == True
   ignore_errors: true
-
-  #Local Hacking
-- name: Debug out the variables
-  debug:
-    msg: " kube_sdn_deploy: {{ kube_sdn_deploy }} , kube_sdn: {{ kube_sdn }} , arm_enabled: {{ arm_enabled }}"
 
 - name: deploying flannel for kubernetes
   shell: kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml

--- a/kube-deploy/roles/kube-sdn/tasks/kube-flannel.yml
+++ b/kube-deploy/roles/kube-sdn/tasks/kube-flannel.yml
@@ -19,15 +19,32 @@
 
 - name: ensure sdn bootstrap directory exists
   file: path=/etc/kubernetes/halcyon/network state=directory
-  when: (kube_sdn_deploy == 'true')
+  when: kube_sdn_deploy == True
   ignore_errors: true
+
+  #Local Hacking
+- name: Debug out the variables
+  debug:
+    msg: " kube_sdn_deploy: {{ kube_sdn_deploy }} , kube_sdn: {{ kube_sdn }} , arm_enabled: {{ arm_enabled }}"
 
 - name: deploying flannel for kubernetes
   shell: kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
   register: deploy_flannel
-  when: (kube_sdn == 'flannel')
+  when: (kube_sdn == 'flannel' and arm_enabled == False)
+  ignore_errors: true
+
+- name: deploying flannel for kubernetes - ARM support only
+  shell: curl -sSL https://rawgit.com/coreos/flannel/master/Documentation/kube-flannel.yml | sed "s/amd64/arm64/g" | kubectl create -f -
+  register: deploy_flannel_arm
+  when: (kube_sdn == 'flannel' and arm_enabled == True)
   ignore_errors: true
 
 - name: flannel deployment stdout
   debug: msg={{ deploy_flannel }}
   ignore_errors: true
+  when: arm_enabled == False
+
+- name: flannel deployment stdout
+  debug: msg={{ deploy_flannel_arm }}
+  ignore_errors: true
+  when: arm_enabled == True


### PR DESCRIPTION
Enabling ARM and ARM64 Support for halcyon-kubernetes deployment feature enhancement requested by @ravishivt 

To enable ARM Support:
1) in group_vars/all.yml, set `arm_enabled: true`
2) set `kube_sdn: flannel`

@ravishivt  -- Let me know if this is the functionality you are looking for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/halcyon-kubernetes/41)
<!-- Reviewable:end -->
