### PR TITLE
Change to use CentOS's Docker rather than upstream

### DIFF
--- a/kube-deploy/roles/deploy-kube/tasks/centos.yml
+++ b/kube-deploy/roles/deploy-kube/tasks/centos.yml
@@ -24,19 +24,10 @@
     gpgkey: https://packages.cloud.google.com/yum/doc/yum-key.gpg
             https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 
-- name: Add docker repository with gpg keys
-  yum_repository:
-    name: docker
-    description: Repository for docker
-    baseurl: https://yum.dockerproject.org/repo/main/centos/7/
-    enabled: yes
-    gpgcheck: yes
-    gpgkey: https://yum.dockerproject.org/gpg
-
 - name: install kubeadm and required prereqs
   yum: name={{ item }} update_cache=yes state=present state=latest
   with_items:
-  - docker-engine
+  - docker
   - kubelet
   - kubeadm
   - kubectl


### PR DESCRIPTION
Provides a fix for: https://github.com/att-comdev/halcyon-kubernetes/issues/42

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/halcyon-kubernetes/43)
<!-- Reviewable:end -->
