### PR TITLE
Adding syntax fixes for CentOS

### DIFF
--- a/kube-deploy/roles/deploy-kube/tasks/centos.yml
+++ b/kube-deploy/roles/deploy-kube/tasks/centos.yml
@@ -21,17 +21,22 @@
     baseurl: http://yum.kubernetes.io/repos/kubernetes-el7-x86_64
     enabled: yes
     gpgcheck: yes
-    gpgkey: https://packages.cloud.google.com/yum/doc/yum-key.gpg
-            https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+    gpgkey: "{{ item }}"
+  with_items:
+    - "https://packages.cloud.google.com/yum/doc/yum-key.gpg"
+    - "https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
 
 - name: install kubeadm and required prereqs
-  yum: name={{ item }} update_cache=yes state=present state=latest
+  yum:
+    name: "{{ item }}"
+    update_cache: yes
+    state: present
   with_items:
-  - docker
-  - kubelet
-  - kubeadm
-  - kubectl
-  - kubernetes-cni
+    - docker
+    - kubelet
+    - kubeadm
+    - kubectl
+    - kubernetes-cni
 
 # Currently SELinux must be turned off to allow containers to access
 # the host filesystem. This is necessary until kubelet can handle
@@ -40,11 +45,16 @@
   command: setenforce 0
 
 - name: setting up docker unit drop-in dir
-  file: path=/etc/systemd/system/docker.service.d state=directory
+  file:
+    path: /etc/systemd/system/docker.service.d
+    state: directory
   when: docker_shared_mounts or proxy_enable
 
 - name: setting up docker shared mounts
-  template: src="10-docker-shared-mounts.conf.j2" dest="/etc/systemd/system/docker.service.d/10-docker-shared-mounts.conf" mode=0640
+  template:
+    src: 10-docker-shared-mounts.conf.j2
+    dest: /etc/systemd/system/docker.service.d/10-docker-shared-mounts.conf
+    mode: 0640
   when: docker_shared_mounts
   register: dsm
 
@@ -52,7 +62,10 @@
 # even if it did, would require a vargrant reload after docker install
 # in order to take effect.
 - name: setting up docker proxy
-  template: src="20-docker-proxy.conf.j2" dest="/etc/systemd/system/docker.service.d/20-docker-proxy.conf" mode=0640
+  template:
+    src: 20-docker-proxy.conf.j2
+    dest: /etc/systemd/system/docker.service.d/20-docker-proxy.conf
+    mode: 0640
   when: proxy_enable
   register: docker_proxy
 
@@ -74,7 +87,10 @@
   command: rm -rf /etc/kubernetes/manifests
 
 - name: add kubelet.service drop-in for hostname override
-  template: src="15-hostname-override.conf.j2" dest="/etc/systemd/system/kubelet.service.d/15-hostname-override.conf" mode=0640
+  template:
+    src: 15-hostname-override.conf.j2
+    dest: /etc/systemd/system/kubelet.service.d/15-hostname-override.conf
+    mode: 0640
   when: kubelet_hostname_override
   register: kho
 


### PR DESCRIPTION
Fixing syntax issues in the CentOS playbooks.  This is causing issues with the jenkins build because Ansible is unable to parse the GPG keys, since they are separated using line breaks. I am moving them to run iteratively using "with_items" instead. Also fixing minor syntax issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/halcyon-kubernetes/44)
<!-- Reviewable:end -->
