### PR TITLE
Fix failures in output

### DIFF
--- a/kube-deploy/roles/kube-init/tasks/ubuntu-masters.yml
+++ b/kube-deploy/roles/kube-init/tasks/ubuntu-masters.yml
@@ -17,6 +17,7 @@
 - name: check for bootstrap
   shell: kubectl get nodes
   register: kube_bootstrap
+  failed_when: false
   ignore_errors: true
 
 - name: debug bootstrap output
@@ -41,6 +42,14 @@
   when: "'localhost:8080 was refused' in kube_bootstrap.stderr and kube_sdn == 'flannel'"
   register: initout
   ignore_errors: true
+
+- name: check kubectl after initializing the kubernetes master
+  shell: kubectl get nodes
+  register: kube_bootstrap
+  ignore_errors: true
+
+- name: debug kubectl output
+  debug: msg="{{ kube_bootstrap }}"
 
 # BELOW ARE TWO DEBUGGING OPTIONS:
 #- name: debug kubernetes init output

--- a/kube-deploy/roles/kube-prep/tasks/prep-host-dns.yml
+++ b/kube-deploy/roles/kube-prep/tasks/prep-host-dns.yml
@@ -59,7 +59,7 @@
 
 # This rather ugly step is required to ensure that all pods have the correct resolv.conf
 - name: forcing all k8s containers to be recreated with correct dns settings
-  shell: docker ps | awk '$NF ~ /^k8s_/ { print $1}' | xargs -l1 docker rm -f
+  shell: docker ps | awk '$NF ~ /^k8s_/ { print $1}' | xargs -l1 -r docker rm -f
   ignore_errors: true
 
 - name: waiting for k8s api to come back up


### PR DESCRIPTION
Since https://github.com/att-comdev/halcyon-kubernetes/blob/master/kube-deploy/roles/kube-init/tasks/ubuntu-masters.yml#L18 displays the expected error `The connection to the server localhost:8080 was refused - did you specify the right host or port?`, Ansible shows this as a failure when it is not a **real** failure (see below).  Hence, added `failed_when: false` for this task.  Also added this task after https://github.com/att-comdev/halcyon-kubernetes/blob/master/kube-deploy/roles/kube-init/tasks/ubuntu-masters.yml#L32-L43 (after initializing the kubernetes master) to make sure that `kubectl` works after the kubernetes master has been initialized.

```
TASK [kube-init : check for bootstrap] *****************************************
fatal: [kube1]: FAILED! => {"changed": true, "cmd": "kubectl get nodes", "delta": "0:00:00.255915", "end": "2017-02-11 06:30:51.426674", "failed": true, "rc": 1, "start": "2017-02-11 06:30:51.170759", "stderr": "The connection to the server localhost:8080 was refused - did you specify the right host or port?", "stdout": "", "stdout_lines": [], "warnings": []}
...ignoring
```

https://github.com/att-comdev/halcyon-kubernetes/blob/master/kube-deploy/roles/kube-prep/tasks/prep-host-dns.yml#L62 fails on kube{2,3,4} as there will be no containers running on them and we see the failure `"docker rm" requires at least 1 argument(s).\nSee 'docker rm --help'` since `xrgs` runs `docker rm -f` with no input (container ID). See below. Hence, added `-r` for `xargs` so that `docker rm -f` is **not** run when there are no containers running. The `-r` option of `xargs` means `--no-run-if-empty`.

```
TASK [kube-prep : forcing all k8s containers to be recreated with correct dns settings] ***
fatal: [kube4]: FAILED! => {"changed": true, "cmd": "docker ps | awk '$NF ~ /^k8s_/ { print $1}' | xargs -l1 docker rm -f", "delta": "0:00:01.419671", "end": "2017-02-11 06:36:11.164915", "failed": true, "rc": 123, "start": "2017-02-11 06:36:09.745244", "stderr": "\"docker rm\" requires at least 1 argument(s).\nSee 'docker rm --help'.\n\nUsage:  docker rm [OPTIONS] CONTAINER [CONTAINER...]\n\nRemove one or more containers", "stdout": "", "stdout_lines": [], "warnings": []}
...ignoring
fatal: [kube2]: FAILED! => {"changed": true, "cmd": "docker ps | awk '$NF ~ /^k8s_/ { print $1}' | xargs -l1 docker rm -f", "delta": "0:00:01.157304", "end": "2017-02-11 06:36:12.779749", "failed": true, "rc": 123, "start": "2017-02-11 06:36:11.622445", "stderr": "\"docker rm\" requires at least 1 argument(s).\nSee 'docker rm --help'.\n\nUsage:  docker rm [OPTIONS] CONTAINER [CONTAINER...]\n\nRemove one or more containers", "stdout": "", "stdout_lines": [], "warnings": []}
...ignoring
fatal: [kube3]: FAILED! => {"changed": true, "cmd": "docker ps | awk '$NF ~ /^k8s_/ { print $1}' | xargs -l1 docker rm -f", "delta": "0:00:01.207939", "end": "2017-02-11 06:36:13.106148", "failed": true, "rc": 123, "start": "2017-02-11 06:36:11.898209", "stderr": "\"docker rm\" requires at least 1 argument(s).\nSee 'docker rm --help'.\n\nUsage:  docker rm [OPTIONS] CONTAINER [CONTAINER...]\n\nRemove one or more containers", "stdout": "", "stdout_lines": [], "warnings": []}
...ignoring
```

The test results are in https://gist.github.com/vhosakot/65095b5904fc07ff1756aa09152c7bfc.

Fixes https://github.com/att-comdev/halcyon-vagrant-kubernetes/issues/48