### PR TITLE
Update to kubernetes 1.5.4

### DIFF
--- a/kube-deploy/group_vars/all.yml
+++ b/kube-deploy/group_vars/all.yml
@@ -24,7 +24,7 @@ proxy_enable: false
 kubectl_endpoint: kube1
 kubelet_hostname_override: true
 init_token: ac7da3.b2cofcda6ab01976
-kube_version: v1.5.1
+kube_version: v1.5.4
 #
 #
 ## Kubernetes SDN Deployment Options:
@@ -65,6 +65,6 @@ setup_host_kube_dns: false
 # Setup the host for ceph
 setup_host_ceph: false
 # Patch kubernetes-controller-manager for ceph PVC support
-# This pulls in the quay.io/attcomdev/kube-controller-manager:v1.5.0-beta.1
+# This pulls in quay.io/attcomdev/kube-controller-manager:v1.5.4
 # to replace the upstream image
 patch_kube_ceph: false


### PR DESCRIPTION
Kubernetes 1.5.4 is alive.  Have halycon development environment
create a kubernetes 1.5.4 cluster.

Someone with appropriate privileges to quay.io/att-comdev will need
to push a new 1.5.4 kubernetes patched kube-controller-manager:1.5.4 image.